### PR TITLE
Add Ears compatibility

### DIFF
--- a/src/main/java/com/kneelawk/magicalmahou/mixin/impl/PlayerSkinTextureAccessor.java
+++ b/src/main/java/com/kneelawk/magicalmahou/mixin/impl/PlayerSkinTextureAccessor.java
@@ -1,0 +1,14 @@
+package com.kneelawk.magicalmahou.mixin.impl;
+
+import net.minecraft.client.texture.NativeImage;
+import net.minecraft.client.texture.PlayerSkinTexture;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import java.io.InputStream;
+
+@Mixin(PlayerSkinTexture.class)
+public interface PlayerSkinTextureAccessor {
+    @Invoker
+    NativeImage callLoadTexture(InputStream stream);
+}

--- a/src/main/kotlin/com/kneelawk/magicalmahou/MMLog.kt
+++ b/src/main/kotlin/com/kneelawk/magicalmahou/MMLog.kt
@@ -26,4 +26,8 @@ object MMLog {
     fun warn(msg: Any, t: Throwable) {
         log.warn(msg, t)
     }
+
+    fun warn(msg: String, obj: Int) {
+        log.warn(msg, obj)
+    }
 }

--- a/src/main/kotlin/com/kneelawk/magicalmahou/client/skin/NativeImageBackedPlayerSkinTexture.kt
+++ b/src/main/kotlin/com/kneelawk/magicalmahou/client/skin/NativeImageBackedPlayerSkinTexture.kt
@@ -1,0 +1,76 @@
+package com.kneelawk.magicalmahou.client.skin
+
+import com.kneelawk.magicalmahou.MMLog
+import com.kneelawk.magicalmahou.mixin.impl.PlayerSkinTextureAccessor
+import com.mojang.blaze3d.platform.TextureUtil
+import com.mojang.blaze3d.systems.RenderSystem
+import net.minecraft.client.texture.NativeImage
+import net.minecraft.client.texture.PlayerSkinTexture
+import net.minecraft.client.util.DefaultSkinHelper
+import net.minecraft.resource.ResourceManager
+import java.io.ByteArrayInputStream
+import java.util.*
+
+class NativeImageBackedPlayerSkinTexture(image: NativeImage, playerUUID: UUID) : PlayerSkinTexture(
+    null, "http://skins.minecraft.net/MinecraftSkins/magical-mahou.png", DefaultSkinHelper.getTexture(playerUUID),
+    false, null
+) {
+
+    var image: NativeImage? = image
+        set(value) {
+            field?.close()
+            field = value
+
+            // Ears compat
+            updateEarsTexture()
+        }
+
+    init {
+        if (!RenderSystem.isOnRenderThread()) {
+            RenderSystem.recordRenderCall {
+                upload()
+            }
+        } else {
+            upload()
+        }
+
+        // Ears compat
+        updateEarsTexture()
+    }
+
+    /**
+     * This calls the PlayerSkinTexture's `loadTexture` function that Ears uses to initialize its texture.
+     */
+    private fun updateEarsTexture() {
+        val image = image
+        if (image != null) {
+            MMLog.info("Enabling Ears compatibility (will do nothing if Ears is not installed)")
+            val bais = ByteArrayInputStream(image.bytes)
+            (this as PlayerSkinTextureAccessor).callLoadTexture(bais)
+        }
+    }
+
+    override fun load(manager: ResourceManager?) {
+        // Don't do any actual loading.
+    }
+
+    fun upload() {
+        val image = image
+        if (image != null) {
+            TextureUtil.prepareImage(getGlId(), image.width, image.height)
+            bindTexture()
+            image.upload(0, 0, 0, false)
+        } else {
+            MMLog.warn("Trying to upload disposed texture {}", getGlId())
+        }
+    }
+
+    override fun close() {
+        val image = image
+        if (image != null) {
+            image.close()
+            clearGlId()
+            this.image = null
+        }
+    }
+}

--- a/src/main/resources/magical-mahou.mixins.json
+++ b/src/main/resources/magical-mahou.mixins.json
@@ -11,6 +11,7 @@
     "MatrixStackEntryAccessor",
     "MouseAccessor",
     "PlayerEntityRendererMixin",
+    "PlayerSkinTextureAccessor",
     "RenderLayerAccessor",
     "RenderPhaseAccessor"
   ],


### PR DESCRIPTION
This PR makes the client player skin manager use a custom subclass of `PlayerSkinTexture` that invokes the Ears hook method when a skin texture is loaded.